### PR TITLE
Enable Klondike training

### DIFF
--- a/Coach.py
+++ b/Coach.py
@@ -79,12 +79,13 @@ class Coach():
 
         for i in range(1, self.args.numIters + 1):
             # bookkeeping
-            log.info(f'Starting Iter #{i} ...')
+            print(f"\n🔁 Iteration {i}/{self.args.numIters}")
             # examples of the iteration
             if not self.skipFirstSelfPlay or i > 1:
                 iterationTrainExamples = deque([], maxlen=self.args.maxlenOfQueue)
 
-                for _ in tqdm(range(self.args.numEps), desc="Self Play"):
+                for eps in range(self.args.numEps):
+                    print(f"  🤖 Self-play game {eps+1}/{self.args.numEps}")
                     self.mcts = MCTS(self.game, self.nnet, self.args)  # reset search tree
                     iterationTrainExamples += self.executeEpisode()
 
@@ -111,12 +112,14 @@ class Coach():
             pmcts = MCTS(self.game, self.pnet, self.args)
 
             self.nnet.train(trainExamples)
+            print("  🎯 Training complete.")
             nmcts = MCTS(self.game, self.nnet, self.args)
 
-            log.info('PITTING AGAINST PREVIOUS VERSION')
+            print("  ⚔️  Pitting new model against previous...")
             arena = Arena(lambda x: np.argmax(pmcts.getActionProb(x, temp=0)),
                           lambda x: np.argmax(nmcts.getActionProb(x, temp=0)), self.game)
             pwins, nwins, draws = arena.playGames(self.args.arenaCompare)
+            print(f"✅ New model won {nwins}/{self.args.arenaCompare} games")
 
             log.info('NEW/PREV WINS : %d / %d ; DRAWS : %d' % (nwins, pwins, draws))
             if pwins + nwins == 0 or float(nwins) / (pwins + nwins) < self.args.updateThreshold:

--- a/main.py
+++ b/main.py
@@ -5,17 +5,14 @@ import coloredlogs
 import argparse
 from Coach import Coach
 from utils import *
+from game.KlondikeGame import KlondikeGame
+from klondike.klondikeNNet import NNet as klondikeNNet
+from othello.OthelloGame import OthelloGame
+from othello.pytorch.NNet import NNetWrapper as othelloNNet
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--game', default='othello', help='Name of the game to train')
 cmd_args, _ = parser.parse_known_args()
-
-if cmd_args.game.lower() == 'klondike':
-    from game.KlondikeGame import KlondikeGame as Game
-    from klondike.klondikeNNet import NNet as nn
-else:
-    from othello.OthelloGame import OthelloGame as Game
-    from othello.pytorch.NNet import NNetWrapper as nn
 
 log = logging.getLogger(__name__)
 
@@ -35,19 +32,22 @@ args = dotdict({
     'load_model': False,
     'load_folder_file': ('/dev/models/8x100x50','best.pth.tar'),
     'numItersForTrainExamplesHistory': 20,
+    'game': cmd_args.game.lower(),
 
 })
 
 
 def main():
-    log.info('Loading %s...', Game.__name__)
-    if cmd_args.game.lower() == 'othello':
-        g = Game(6)
+    if args.game == 'klondike':
+        log.info('Loading KlondikeGame...')
+        g = KlondikeGame()
+        nnet = klondikeNNet(g)
+    elif args.game == 'othello':
+        log.info('Loading OthelloGame...')
+        g = OthelloGame(6)
+        nnet = othelloNNet(g)
     else:
-        g = Game()
-
-    log.info('Loading %s...', nn.__name__)
-    nnet = nn(g)
+        raise ValueError(f"Unknown game {args.game}")
 
     if args.load_model:
         log.info('Loading checkpoint "%s/%s"...', args.load_folder_file[0], args.load_folder_file[1])

--- a/test_klondike.py
+++ b/test_klondike.py
@@ -1,0 +1,17 @@
+from game.KlondikeGame import KlondikeGame
+from klondike.klondikeNNet import NNet as KlondikeNNet
+from MCTS import MCTS
+import numpy as np
+
+# minimal self-play loop to ensure interaction between game and network
+if __name__ == "__main__":
+    game = KlondikeGame()
+    nnet = KlondikeNNet(game)
+    mcts = MCTS(game, nnet, args={'numMCTSSims': 25, 'cpuct': 1.0})
+
+    board = game.getInitBoard()
+    pi = mcts.getActionProb(board, temp=1)
+
+    print("Initial board:\n", board)
+    print("Policy:\n", pi)
+    print("Valid moves:\n", game.getValidMoves(board, 1))


### PR DESCRIPTION
## Summary
- add imports for Klondike in `main.py`
- instantiate Klondike game and network when `--game klondike` is passed
- provide a small `test_klondike.py` self‑play check
- improve training logs in `Coach.learn`

## Testing
- `python -m py_compile main.py Coach.py test_klondike.py`
- `python test_klondike.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `python main.py --game klondike -h` *(fails: OSError: libtorch_global_deps.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6870ed9ac208833282e1bec36de41b65